### PR TITLE
Added inentory-database and inventory as helm charts

### DIFF
--- a/inventory-database-helm/.helmignore
+++ b/inventory-database-helm/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/inventory-database-helm/Chart.yaml
+++ b/inventory-database-helm/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: inventory-database
+description: coolstore-yaml inventory-database
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "0.1"

--- a/inventory-database-helm/templates/_helpers.tpl
+++ b/inventory-database-helm/templates/_helpers.tpl
@@ -1,0 +1,75 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "inventory-database.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "inventory-database.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "inventory-database.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "inventory-database.labels" -}}
+helm.sh/chart: {{ include "inventory-database.chart" . }}
+app: postgresql-persistent
+app.kubernetes.io/component: postgresql-persistent
+app.kubernetes.io/instance: postgresql-persistent
+app.kubernetes.io/part-of: inventory
+app.openshift.io/runtime: postgresql
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "inventory-database.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "inventory-database.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Storage labels
+*/}}
+{{- define "inventory-database.appLabels" -}}
+app: postgresql-persistent
+app.kubernetes.io/component: postgresql-persistent
+app.kubernetes.io/instance: postgresql-persistent
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "inventory-database.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "inventory-database.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/inventory-database-helm/templates/deployment.yaml
+++ b/inventory-database-helm/templates/deployment.yaml
@@ -1,0 +1,79 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    {{ include "inventory-database.labels" . | nindent 4 }}
+  name: {{ include "inventory-database.name" . | nindent 2 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      name: {{ include "inventory-database.name" . | nindent 6 }}
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+      name: {{ include "inventory-database.fullname" . | nindent  8 }}
+    spec:
+      containers:
+      - env:
+        - name: POSTGRESQL_USER
+          valueFrom:
+            secretKeyRef:
+              key: database-user
+              name: "{{ .Release.Name }}-secret"
+        - name: POSTGRESQL_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: database-password
+              name: "{{ .Release.Name }}-secret"
+        - name: POSTGRESQL_DATABASE
+          valueFrom:
+            secretKeyRef:
+              key: database-name
+              name: "{{ .Release.Name }}-secret"
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.pullPolicy }}
+        livenessProbe:
+          exec:
+            command:
+            - /usr/libexec/check-container
+            - --live
+          failureThreshold: 3
+          initialDelaySeconds: 120
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 10
+        name: postgresql
+        ports:
+        - containerPort: 5432
+          protocol: TCP
+        readinessProbe:
+          exec:
+            command:
+            - /usr/libexec/check-container
+          failureThreshold: 3
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources:
+          limits:
+            memory: 512Mi
+        securityContext:
+          privileged: false
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /var/lib/pgsql/data
+          name: inventory-database-data
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - name: inventory-database-data
+        persistentVolumeClaim:
+          claimName: {{ include "inventory-database.name" . | nindent 10 }}

--- a/inventory-database-helm/templates/pvc.yaml
+++ b/inventory-database-helm/templates/pvc.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    {{ include "inventory-database.appLabels" . | nindent 4 }}
+  name: {{ include "inventory-database.name" . | nindent 2 }}
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.storage.requests.size | quote | default "1Gi" }}
+  storageClassName: standard

--- a/inventory-database-helm/templates/secret.yaml
+++ b/inventory-database-helm/templates/secret.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+data:
+  database-name: {{ required "you must include dbCredentials.name value" .Values.dbCredentials.name }}
+  database-password: {{ required "you must include dbCredentials.password value" .Values.dbCredentials.password }}
+  database-user: {{ required "you must include dbCredentials.user value" .Values.dbCredentials.user}}
+kind: Secret
+metadata:
+  labels:
+    {{ include "inventory-database.appLabels" . | nindent 4 }}
+  name: {{ include "inventory-database.name" . | nindent 2 }}
+type: Opaque

--- a/inventory-database-helm/templates/service.yaml
+++ b/inventory-database-helm/templates/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    {{ include "inventory-database.appLabels" . | nindent 4 }}
+  name: {{ include "inventory-database.name" . | nindent 2 }}
+spec:
+  ports:
+  - name: postgresql
+    port: {{ required "You must include service.port value" .Values.service.port }}
+  selector:
+    name: {{ include "inventory-database.name" . | nindent 4 }}

--- a/inventory-database-helm/templates/tests/route.yaml
+++ b/inventory-database-helm/templates/tests/route.yaml
@@ -1,0 +1,13 @@
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ include "inventory-database.fullname" . }}
+spec:
+  host: {{ .Values.host }}
+  port:
+    targetPort: "{{ .Values.service.port }}-tcp"
+  to:
+    kind: Service
+    name: {{ .Release.Name }}
+    weight: 100
+  wildcardPolicy: None

--- a/inventory-database-helm/templates/tests/test-connection.yaml
+++ b/inventory-database-helm/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "inventory-database.fullname" .  }}-test-connection"
+  labels:
+{{ include "inventory-database.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test-success
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args:  ['{{ include "inventory-database.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/inventory-database-helm/values.yaml
+++ b/inventory-database-helm/values.yaml
@@ -1,0 +1,62 @@
+# Default values for inventory-database.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: image-registry.openshift-image-registry.svc:5000/openshift/postgresql
+  pullPolicy: IfNotPresent
+  tag: 10-el8
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext: {}
+
+securityContext: {}
+
+service:
+  port: 5432
+
+ingress:
+  enabled: false
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: inventory-wkosp-coolstore.apps.cluster-wkosp.dynamic.opentlc.com
+      paths: []
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+resources: {}
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+storage:
+  requests:
+    size: 1Gi
+
+dbCredentials:
+  name: aW52ZW50b3J5 
+  password: aW52ZW50b3J5
+  user: aW52ZW50b3J5

--- a/inventory-helm/.helmignore
+++ b/inventory-helm/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/inventory-helm/Chart.yaml
+++ b/inventory-helm/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: inventory
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.16.0"

--- a/inventory-helm/templates/_helpers.tpl
+++ b/inventory-helm/templates/_helpers.tpl
@@ -1,0 +1,77 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "inventory.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "inventory.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "inventory.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "inventory.labels" -}}
+helm.sh/chart: {{ include "inventory.chart" . }}
+app: inventory
+app.kubernetes.io/component: {{ include "inventory.name" . }}
+app.kubernetes.io/instance: {{ include "inventory.name" . }}
+app.kubernetes.io/part-of: {{ include "inventory.name" . }}
+app.openshift.io/runtime: quarkus
+{{ include "inventory.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "inventory.selectorLabels" -}}
+app.kubernetes.io/part-of: inventory
+app.openshift.io/runtime: quarkus
+deployment: {{ include "inventory.name" . }}
+{{- end }}
+
+{{/*
+buildConfig labels
+*/}}
+{{- define "inventory.bcLabels" -}}
+app.kubernetes.io/name: {{ include "inventory.name" . }}
+app.kubernetes.io/version: 1.0-SNAPSHOT
+app.openshift.io/runtime: quarkus
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "inventory.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "inventory.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/inventory-helm/templates/buildConfig.yaml
+++ b/inventory-helm/templates/buildConfig.yaml
@@ -1,0 +1,23 @@
+apiVersion: build.openshift.io/v1
+kind: BuildConfig
+metadata:
+  labels:
+    {{ include "inventory.bcLabels" . | nindent 4 }}
+  name: {{ .Release.Name }}
+spec:
+  failedBuildsHistoryLimit: 5
+  output:
+    to:
+      kind: ImageStreamTag
+      name: inventory:latest
+  runPolicy: Serial
+  source:
+    type: Binary
+  strategy:
+    sourceStrategy:
+      from:
+        kind: ImageStreamTag
+        name: ubi8-openjdk-11:1.3
+        namespace: openshift
+    type: Source
+  successfulBuildsHistoryLimit: 5

--- a/inventory-helm/templates/deployment.yaml
+++ b/inventory-helm/templates/deployment.yaml
@@ -1,0 +1,72 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    app.openshift.io/connects-to: '["inventory-database",{"apiVersion":"apps/v1","kind":"Deployment","name":"inventory-database"}]'
+  labels:
+    {{ include "inventory.labels" . | nindent 4 }}
+    ;
+  name: {{ include "inventory.name" . }}
+spec:
+  progressDeadlineSeconds: 600
+  replicas: {{ .Values.replicaCount }}
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      {{ include "inventory.selectorLabels " . | nindent 6 }}
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        {{ include "inventory.selectorLabels" . | nindent 8 }}
+    spec:
+      containers:
+      - env:
+        - name: quarkus.datasource.driver
+          value: org.postgresql.Driver
+        - name: quarkus.datasource.password
+          value: {{ include "inventory.name" . | nindent 10 }}
+        - name: quarkus.datasource.url
+          value: jdbc:postgresql://inventory-database:5432/inventory
+        - name: quarkus.datasource.username
+          value: {{ include "inventory.name" . | nindent 10 }}
+        - name: QUARKUS_DATASOURCE_USERNAME
+          valueFrom:
+            secretKeyRef:
+              key: quarkus.datasource.username
+              name: {{ include "inventory.name" . | nindent 14 }}
+        - name: QUARKUS_DATASOURCE_DRIVER
+          valueFrom:
+            secretKeyRef:
+              key: quarkus.datasource.driver
+              name: {{ include "inventory.name" | nindent 14 }}
+        - name: QUARKUS_DATASOURCE_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: quarkus.datasource.password
+              name: {{ include "inventory.name" | nindent 14 }}
+        - name: QUARKUS_DATASOURCE_URL
+          valueFrom:
+            secretKeyRef:
+              key: quarkus.datasource.url
+              name: {{ include "inventory.name" | nindent 14 }}
+        image: "{{ required "You must include image.repository and image.tag" .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        name: {{ .Release.Name }}
+        ports:
+        - containerPort: {{ .Values.service.port1 }}
+          protocol: TCP
+        - containerPort: {{ .Values.service.port2 }}
+          protocol: TCP
+        - containerPort: {{ .Values.service.port3 }}
+          protocol: TCP
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      terminationGracePeriodSeconds: 30

--- a/inventory-helm/templates/route.yaml
+++ b/inventory-helm/templates/route.yaml
@@ -1,0 +1,14 @@
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  labels:
+    {{ include "inventory.labels" . | nindent 4 }}
+  name: {{ .Release.Name }}
+spec:
+  port:
+    targetPort: "{{ .Values.service.port1 }}-tcp"
+  to:
+    kind: Service
+    name: {{ .Release.Name }}
+    weight: 100
+  wildcardPolicy: None

--- a/inventory-helm/templates/secret.yaml
+++ b/inventory-helm/templates/secret.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+data:
+  quarkus.datasource.driver: {{ .Values.quarkusSecret.driver }}
+  quarkus.datasource.password: {{ .Values.quarkusSecret.password }}
+  quarkus.datasource.url: {{ .Values.quarkusSecret.url }}
+  quarkus.datasource.username: {{ .Values.quarkusSecret.username }}
+kind: Secret
+metadata:
+  name: inventory
+type: Opaque

--- a/inventory-helm/templates/service.yaml
+++ b/inventory-helm/templates/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    {{ include "inventory.labels" . | nindent 4 }}
+  name: {{ include "inventory.fullname" . }}
+spec:
+  ports:
+  - name: "{{ .Values.service.port1 }}-tcp"
+    port: {{ .Values.service.port1 }}
+  - name: "{{ .Values.service.port2 }}-tcp"
+    port: {{ .Values.service.port2 }}
+  - name: "{{ .Values.service.port3 }}-tcp"
+    port: {{ .Values.service.port3 }}
+  selector:
+    {{ include "inventory.selectorLabels" . | nindent 4 }}

--- a/inventory-helm/templates/tests/test-connection.yaml
+++ b/inventory-helm/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "inventory.fullname" . }}-test-connection"
+  labels:
+    {{- include "inventory.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "inventory.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/inventory-helm/values.yaml
+++ b/inventory-helm/values.yaml
@@ -1,0 +1,87 @@
+# Default values for inventory.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: image-registry.openshift-image-registry.svc:5000/wkosp-coolstore/inventory
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: dev-31
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+service:
+  type: ClusterIP
+  port1: 8080
+  port2: 8443
+  port3: 8778
+
+ingress:
+  enabled: false
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: chart-example.local
+      paths: []
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+quarkusSecret:
+  driver: b3JnLnBvc3RncmVzcWwuRHJpdmVy
+  password: aW52ZW50b3J5
+  url: amRiYzpwb3N0Z3Jlc3FsOi8vaW52ZW50b3J5LWRhdGFiYXNlOjU0MzIvaW52ZW50b3J5
+  username: aW52ZW50b3J5


### PR DESCRIPTION
Added inventory-database as helm charts.
- ./templates/*.yaml will define several objects needed by application itself.
- ./Chart.yml is an entry point to the chart, it defines the type of chart, version of the chart and also appVersion itself, evolving chart should use this file to versioning inventory-database 
- values.yaml is a live file to be changed in depends how templates are defined and which values should be resolved by this file.
- I included several options of using pipes, defaulting values, quoting and so on.
- Make usage of helpers in templates.